### PR TITLE
SSGをSSRに変更

### DIFF
--- a/pages/top.js
+++ b/pages/top.js
@@ -12,6 +12,18 @@ import { makeStyles } from '@material-ui/core/styles';
 import { AppLayout } from 'src/components/organisms/AppLayout';
 import { AppHead } from 'src/components/organisms/AppHead';
 
+/******************************************************************
+ * TODO:
+ * 20201026 暫定対処                                                                       
+ * SSGだと新規手記投稿の結果をユーザページが認識せず古いHTMLを見せ続ける
+ * この問題は手記ページとセクションページでも同様に起きる
+ * URLでダイレクトにページにアクセスするとフォールバック機能でページは生成
+ * されるが、親ページにそれが伝わらないためと考える
+ * 暫定対処として、getStaticPathsを削除
+ * getStaticPropsをgetServerSidePropsに変更する
+ * 対処が必要ないページもあると思うが取り急ぎ全ソースコードそのようにする
+ ******************************************************************/
+
 /**
  * 静的パラメータ取得
  *
@@ -19,7 +31,8 @@ import { AppHead } from 'src/components/organisms/AppHead';
  * @param {*} { params }
  * @return {*}
  */
-export const getStaticProps = async ({ params }) => {
+export const getServerSideProps = async ({ params }) => {
+// export const getStaticProps = async ({ params }) => {
   const userDataList = await getUserDataList();
 
   const bookDataList = await getBookDataList();

--- a/pages/users/[userName].js
+++ b/pages/users/[userName].js
@@ -10,25 +10,37 @@ import { UserPageMain } from 'src/components/templates/userPage/UserPageMain';
 import { AppHead } from 'src/components/organisms/AppHead';
 import { AppLayout } from 'src/components/organisms/AppLayout';
 
+/******************************************************************
+ * TODO:
+ * 20201026 暫定対処                                                                       
+ * SSGだと新規手記投稿の結果をユーザページが認識せず古いHTMLを見せ続ける
+ * この問題は手記ページとセクションページでも同様に起きる
+ * URLでダイレクトにページにアクセスするとフォールバック機能でページは生成
+ * されるが、親ページにそれが伝わらないためと考える
+ * 暫定対処として、getStaticPathsを削除
+ * getStaticPropsをgetServerSidePropsに変更する
+ * 対処が必要ないページもあると思うが取り急ぎ全ソースコードそのようにする
+ ******************************************************************/
+
 /**
  * 静的パス取得
  *
  * @export
  * @return {*}
  */
-export const getStaticPaths = async () => {
-  // すべてのユーザ名を含んだパス生成用配列を取得
-  const paths = await getAllUserNamesPaths();
+// export const getStaticPaths = async () => {
+//   // すべてのユーザ名を含んだパス生成用配列を取得
+//   const paths = await getAllUserNamesPaths();
 
-  // デバッグ情報
-  // if (paths) {
-  //   paths.map((p) => {
-  //     console.log(`SSG対象ユーザページ ${p.params.userName}`);
-  //   });
-  // }
+//   // デバッグ情報
+//   // if (paths) {
+//   //   paths.map((p) => {
+//   //     console.log(`SSG対象ユーザページ ${p.params.userName}`);
+//   //   });
+//   // }
 
-  return { paths, fallback: true };
-};
+//   return { paths, fallback: true };
+// };
 
 /**
  * 静的パラメータ取得
@@ -37,8 +49,8 @@ export const getStaticPaths = async () => {
  * @param {*} { params }
  * @return {*}
  */
-// export async function getStaticProps({ params }) {
-export const getStaticProps = async ({ params }) => {
+export const getServerSideProps = async ({ params }) => {
+// export const getStaticProps = async ({ params }) => {
   // パスから切り出された値が入っている
   const { userName } = params;
 

--- a/pages/users/[userName]/[bookName].js
+++ b/pages/users/[userName]/[bookName].js
@@ -8,28 +8,40 @@ import {
 import { AppLayout } from 'src/components/organisms/AppLayout';
 import BookPageMain from 'src/components/templates/bookPage/BookPageMain';
 
+/******************************************************************
+ * TODO:
+ * 20201026 暫定対処                                                                       
+ * SSGだと新規手記投稿の結果をユーザページが認識せず古いHTMLを見せ続ける
+ * この問題は手記ページとセクションページでも同様に起きる
+ * URLでダイレクトにページにアクセスするとフォールバック機能でページは生成
+ * されるが、親ページにそれが伝わらないためと考える
+ * 暫定対処として、getStaticPathsを削除
+ * getStaticPropsをgetServerSidePropsに変更する
+ * 対処が必要ないページもあると思うが取り急ぎ全ソースコードそのようにする
+ ******************************************************************/
+
 /**
  * 静的パス取得
  *
  * @export
  * @return {Array} 静的パスを生成するための名称の配列
  */
-export async function getStaticPaths() {
+// export async function getStaticPaths() {
 
-  // すべてのユーザ名とブック名を含んだパス生成用配列を取得
-  const paths = await getAllBookNamePaths();
+//   // すべてのユーザ名とブック名を含んだパス生成用配列を取得
+//   const paths = await getAllBookNamePaths();
 
-  // デバッグ情報
-  // if (paths) {
-  //   paths.map((p) =>
-  //     console.log(
-  //       `SSG対象ブックページ ${p.params.userName}/${p.params.bookName}`,
-  //     ),
-  //   );
-  // }
+//   // デバッグ情報
+//   // if (paths) {
+//   //   paths.map((p) =>
+//   //     console.log(
+//   //       `SSG対象ブックページ ${p.params.userName}/${p.params.bookName}`,
+//   //     ),
+//   //   );
+//   // }
 
-  return { paths, fallback: true };
-}
+//   return { paths, fallback: true };
+// }
 
 /**
  * 静的パラメータ取得
@@ -39,7 +51,8 @@ export async function getStaticPaths() {
  * @param {*} { params.bookName 'パスから切り出された値'}
  * @return {*}
  */
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
+// export async function getStaticProps({ params }) {
 
   const { userName, bookName } = params;
 

--- a/pages/users/[userName]/[bookName]/[sectionId].js
+++ b/pages/users/[userName]/[bookName]/[sectionId].js
@@ -12,29 +12,41 @@ import SectionPageMain from 'src/components/templates/sectionPage/SectionPageMai
 
 import { AppLayout } from 'src/components/organisms/AppLayout';
 
+/******************************************************************
+ * TODO:
+ * 20201026 暫定対処                                                                       
+ * SSGだと新規手記投稿の結果をユーザページが認識せず古いHTMLを見せ続ける
+ * この問題は手記ページとセクションページでも同様に起きる
+ * URLでダイレクトにページにアクセスするとフォールバック機能でページは生成
+ * されるが、親ページにそれが伝わらないためと考える
+ * 暫定対処として、getStaticPathsを削除
+ * getStaticPropsをgetServerSidePropsに変更する
+ * 対処が必要ないページもあると思うが取り急ぎ全ソースコードそのようにする
+ ******************************************************************/
+
 /**
  * 静的パス取得
  *
  * @export
  * @return {*}
  */
-export async function getStaticPaths() {
-  // すべてのユーザ名とブック名とセクションIDを含んだパス生成用配列を取得
-  const paths = await getAllSectionIdPaths();
+// export async function getStaticPaths() {
+//   // すべてのユーザ名とブック名とセクションIDを含んだパス生成用配列を取得
+//   const paths = await getAllSectionIdPaths();
 
-  //
-  // デバッグ情報
-  //
-  // if (paths) {
-  //   paths.map((p) => {
-  //     console.log(
-  //       `SSG対象セクションページ ${p.params.userName}/${p.params.bookName}/${p.params.sectionId}`,
-  //     );
-  //   });
-  // }
+//   //
+//   // デバッグ情報
+//   //
+//   // if (paths) {
+//   //   paths.map((p) => {
+//   //     console.log(
+//   //       `SSG対象セクションページ ${p.params.userName}/${p.params.bookName}/${p.params.sectionId}`,
+//   //     );
+//   //   });
+//   // }
 
-  return { paths, fallback: true };
-}
+//   return { paths, fallback: true };
+// }
 
 /**
  * 静的パラメータ取得
@@ -43,7 +55,8 @@ export async function getStaticPaths() {
  * @param {*} { params }
  * @return {*}
  */
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
+// export async function getStaticProps({ params }) {
   const { userName, bookName, sectionId } = params;
 
   // ユーザネームからユーザデータを取得

--- a/pages/users/[userName]/[bookName]/[sectionId]/section-edit.js
+++ b/pages/users/[userName]/[bookName]/[sectionId]/section-edit.js
@@ -28,17 +28,29 @@ import image from 'public/hana_07F.jpg';
 // スタイル設定
 const useStyles = makeStyles(signupPageStyle);
 
+/******************************************************************
+ * TODO:
+ * 20201026 暫定対処                                                                       
+ * SSGだと新規手記投稿の結果をユーザページが認識せず古いHTMLを見せ続ける
+ * この問題は手記ページとセクションページでも同様に起きる
+ * URLでダイレクトにページにアクセスするとフォールバック機能でページは生成
+ * されるが、親ページにそれが伝わらないためと考える
+ * 暫定対処として、getStaticPathsを削除
+ * getStaticPropsをgetServerSidePropsに変更する
+ * 対処が必要ないページもあると思うが取り急ぎ全ソースコードそのようにする
+ ******************************************************************/
+
 /**
  * 静的パス取得
  *
  * @export
  * @return {*}
  */
-export async function getStaticPaths() {
-  const paths = [];
+// export async function getStaticPaths() {
+//   const paths = [];
 
-  return { paths, fallback: true };
-}
+//   return { paths, fallback: true };
+// }
 
 /**
  * 静的パラメータ取得
@@ -47,7 +59,8 @@ export async function getStaticPaths() {
  * @param {*} { params }
  * @return {*}
  */
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
+// export async function getStaticProps({ params }) {
   const { userName, bookName, sectionId } = params;
 
   // ユーザネームからユーザデータを取得

--- a/pages/users/[userName]/[bookName]/book-edit.js
+++ b/pages/users/[userName]/[bookName]/book-edit.js
@@ -27,17 +27,28 @@ import image from 'public/hana_07F.jpg';
 // スタイル設定
 const useStyles = makeStyles(signupPageStyle);
 
+/******************************************************************
+ * TODO:
+ * 20201026 暫定対処                                                                       
+ * SSGだと新規手記投稿の結果をユーザページが認識せず古いHTMLを見せ続ける
+ * この問題は手記ページとセクションページでも同様に起きる
+ * URLでダイレクトにページにアクセスするとフォールバック機能でページは生成
+ * されるが、親ページにそれが伝わらないためと考える
+ * 暫定対処として、getStaticPathsを削除
+ * getStaticPropsをgetServerSidePropsに変更する
+ * 対処が必要ないページもあると思うが取り急ぎ全ソースコードそのようにする
+ ******************************************************************/
 /**
  * 静的パス取得
  *
  * @export
  * @return {*}
  */
-export async function getStaticPaths() {
-  const paths = [];
+// export async function getStaticPaths() {
+//   const paths = [];
 
-  return { paths, fallback: true };
-}
+//   return { paths, fallback: true };
+// }
 
 /**
  * 静的パラメータ取得
@@ -46,7 +57,8 @@ export async function getStaticPaths() {
  * @param {*} aa
  * @return {*}
  */
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
+// export async function getStaticProps({ params }) {
   const { userName, bookName } = params;
   // console.log({ userName });
   // console.log({ bookName });

--- a/pages/users/[userName]/[bookName]/section-create.js
+++ b/pages/users/[userName]/[bookName]/section-create.js
@@ -27,17 +27,29 @@ import image from 'public/hana_07F.jpg';
 // スタイル設定
 const useStyles = makeStyles(signupPageStyle);
 
+/******************************************************************
+ * TODO:
+ * 20201026 暫定対処                                                                       
+ * SSGだと新規手記投稿の結果をユーザページが認識せず古いHTMLを見せ続ける
+ * この問題は手記ページとセクションページでも同様に起きる
+ * URLでダイレクトにページにアクセスするとフォールバック機能でページは生成
+ * されるが、親ページにそれが伝わらないためと考える
+ * 暫定対処として、getStaticPathsを削除
+ * getStaticPropsをgetServerSidePropsに変更する
+ * 対処が必要ないページもあると思うが取り急ぎ全ソースコードそのようにする
+ ******************************************************************/
+
 /**
  * 静的パス取得
  *
  * @export
  * @return {*}
  */
-export async function getStaticPaths() {
-  const paths = [];
+// export async function getStaticPaths() {
+//   const paths = [];
 
-  return { paths, fallback: true };
-}
+//   return { paths, fallback: true };
+// }
 
 /**
  * 静的パラメータ取得
@@ -46,7 +58,8 @@ export async function getStaticPaths() {
  * @param {*} aa
  * @return {*}
  */
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
+// export async function getStaticProps({ params }) {
   const { userName, bookName } = params;
   // console.log({ userName });
   // console.log({ bookName });

--- a/pages/users/[userName]/book-create.js
+++ b/pages/users/[userName]/book-create.js
@@ -21,6 +21,18 @@ import { AppLayout } from 'src/components/organisms/AppLayout';
 import { AuthContext } from 'pages/_app';
 import image from 'public/hana_07F.jpg';
 
+/******************************************************************
+ * TODO:
+ * 20201026 暫定対処                                                                       
+ * SSGだと新規手記投稿の結果をユーザページが認識せず古いHTMLを見せ続ける
+ * この問題は手記ページとセクションページでも同様に起きる
+ * URLでダイレクトにページにアクセスするとフォールバック機能でページは生成
+ * されるが、親ページにそれが伝わらないためと考える
+ * 暫定対処として、getStaticPathsを削除
+ * getStaticPropsをgetServerSidePropsに変更する
+ * 対処が必要ないページもあると思うが取り急ぎ全ソースコードそのようにする
+ ******************************************************************/
+
 // スタイル設定
 const useStyles = makeStyles(signupPageStyle);
 
@@ -30,11 +42,11 @@ const useStyles = makeStyles(signupPageStyle);
  * @export
  * @return {*}
  */
-export async function getStaticPaths() {
-  const paths = [];
+// export async function getStaticPaths() {
+//   const paths = [];
 
-  return { paths, fallback: true };
-}
+//   return { paths, fallback: true };
+// }
 
 /**
  * 静的パラメータ取得
@@ -44,7 +56,8 @@ export async function getStaticPaths() {
  * @param {*} { params.bookName 'パスから切り出された値'}
  * @return {*}
  */
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
+// export async function getStaticProps({ params }) {
   // デバッグ情報
   // console.log('\nファイル /pages/users/[userName]/[bookName].js');
   // console.log('関数 getStaticProps');

--- a/pages/users/[userName]/user-edit.js
+++ b/pages/users/[userName]/user-edit.js
@@ -24,17 +24,29 @@ import image from 'public/hana_07F.jpg';
 // スタイル設定
 const useStyles = makeStyles(signupPageStyle);
 
+/******************************************************************
+ * TODO:
+ * 20201026 暫定対処                                                                       
+ * SSGだと新規手記投稿の結果をユーザページが認識せず古いHTMLを見せ続ける
+ * この問題は手記ページとセクションページでも同様に起きる
+ * URLでダイレクトにページにアクセスするとフォールバック機能でページは生成
+ * されるが、親ページにそれが伝わらないためと考える
+ * 暫定対処として、getStaticPathsを削除
+ * getStaticPropsをgetServerSidePropsに変更する
+ * 対処が必要ないページもあると思うが取り急ぎ全ソースコードそのようにする
+ ******************************************************************/
+
 /**
  * 静的パス取得
  *
  * @export
  * @return {*}
  */
-export async function getStaticPaths() {
-  const paths = [];
+// export async function getStaticPaths() {
+//   const paths = [];
 
-  return { paths, fallback: true };
-}
+//   return { paths, fallback: true };
+// }
 
 /**
  * 静的パラメータ取得
@@ -43,7 +55,8 @@ export async function getStaticPaths() {
  * @param {*} { params }
  * @return {*}
  */
-export const getStaticProps = async ({ params }) => {
+export const getServerSideProps = async ({ params }) => {
+// export const getStaticProps = async ({ params }) => {
   // パスから切り出された値が入っている
   const { userName } = params;
 


### PR DESCRIPTION
/******************************************************************
 * TODO:
 * 20201026 暫定対処                                                                       
 * SSGだと新規手記投稿の結果をユーザページが認識せず古いHTMLを見せ続ける
 * この問題は手記ページとセクションページでも同様に起きる
 * URLでダイレクトにページにアクセスするとフォールバック機能でページは生成
 * されるが、親ページにそれが伝わらないためと考える
 * 暫定対処として、getStaticPathsを削除
 * getStaticPropsをgetServerSidePropsに変更する
 * 対処が必要ないページもあると思うが取り急ぎ全ソースコードそのようにする
 ******************************************************************/